### PR TITLE
upgrade to GWT 2.8.0-beta1 and fix the Long serialization (removed from LongLib)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <gwt.version>2.7.0</gwt.version>
+    <gwt.version>2.8.0-beta1</gwt.version>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
     <plugin.maven.compiler.version>3.0</plugin.maven.compiler.version>

--- a/src/main/java/com/seanchenxi/gwt/storage/client/serializer/StorageSerializationStreamWriter.java
+++ b/src/main/java/com/seanchenxi/gwt/storage/client/serializer/StorageSerializationStreamWriter.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.ListIterator;
 
 import com.google.gwt.core.client.JsonUtils;
-import com.google.gwt.lang.LongLib;
 import com.google.gwt.user.client.rpc.SerializationException;
 import com.google.gwt.user.client.rpc.impl.AbstractSerializationStreamWriter;
 import com.google.gwt.user.client.rpc.impl.Serializer;
@@ -63,7 +62,7 @@ final class StorageSerializationStreamWriter extends AbstractSerializationStream
 
   @Override
   public void writeLong(long value) {
-    append(APOSTROPHE + LongLib.toBase64(value) + APOSTROPHE);
+    append(APOSTROPHE + toBase64(value) + APOSTROPHE);
   }
 
   @Override
@@ -116,4 +115,50 @@ final class StorageSerializationStreamWriter extends AbstractSerializationStream
     append(buffer, table);
   }
 
+  /**
+   * Copy from Base64Utils.toBase64
+   *
+   * An array mapping size but values to the characters that will be used to
+   * represent them. Note that this is not identical to the set of characters
+   * used by MIME-Base64.
+   */
+  private static final char[] base64Chars = new char[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+      'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b',
+      'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+      'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3',
+      '4', '5', '6', '7', '8', '9', '$', '_'};
+
+  public static String toBase64(long value) {
+    // Convert to ints early to avoid need for long ops
+    int low = (int) (value & 0xffffffff);
+    int high = (int) (value >> 32);
+
+    StringBuilder sb = new StringBuilder();
+    boolean haveNonZero = base64Append(sb, (high >> 28) & 0xf, false);
+    haveNonZero = base64Append(sb, (high >> 22) & 0x3f, haveNonZero);
+    haveNonZero = base64Append(sb, (high >> 16) & 0x3f, haveNonZero);
+    haveNonZero = base64Append(sb, (high >> 10) & 0x3f, haveNonZero);
+    haveNonZero = base64Append(sb, (high >> 4) & 0x3f, haveNonZero);
+    int v = ((high & 0xf) << 2) | ((low >> 30) & 0x3);
+    haveNonZero = base64Append(sb, v, haveNonZero);
+    haveNonZero = base64Append(sb, (low >> 24) & 0x3f, haveNonZero);
+    haveNonZero = base64Append(sb, (low >> 18) & 0x3f, haveNonZero);
+    haveNonZero = base64Append(sb, (low >> 12) & 0x3f, haveNonZero);
+    base64Append(sb, (low >> 6) & 0x3f, haveNonZero);
+    base64Append(sb, low & 0x3f, true);
+
+    return sb.toString();
+  }
+
+  private static boolean base64Append(StringBuilder sb, int digit,
+                                      boolean haveNonZero) {
+    if (digit > 0) {
+      haveNonZero = true;
+    }
+    if (haveNonZero) {
+      sb.append(base64Chars[digit]);
+    }
+    return haveNonZero;
+  }
 }


### PR DESCRIPTION
in GWT 2.8.0, LongLib.toBase64 has been removed. So I copied the implementation from Base64Utils.toBase64.
